### PR TITLE
Fix for issue #17

### DIFF
--- a/lib/image.php
+++ b/lib/image.php
@@ -186,7 +186,7 @@
 	}
 
 	// The 'image_path' may change and point to a cache file, but we will
-	// still need to know the requested file; we call it 'original_file'.
+	// still need to know which file is supposed to be processed.
 	$original_file = $image_path;
 
 	// If CACHING is enabled, check to see that the cached file is still valid.


### PR DESCRIPTION
The first two commits should finally fix issue #17. All the time the logical problem was that the `$image_path` variable was changing dynamically. So I added a new variable named `$original_file`. Now checking if the original file exists is rather bulletproof.

@brendo: In the third commit I removed the newly introduced check for `$last_modified`. I assume that it was supposed to do the same as the code further down (i.e. check if the original file exists) — we should not do it twice. If there was another reason to add this, please feel free to re-introduce this.
