### PR TITLE
Recipes alerts

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -270,6 +270,12 @@
 	-------------------------------------------------------------------------*/
 
 		public function appendPreferences($context){
+			// Check if JIT configuration folder exists
+			if (!file_exists(WORKSPACE . '/jit-image-manipulation/')) {
+				Symphony::Engine()->Page->pageAlert(__('The JIT configuration folder, %s, does not exist. You will not be able to save recipes and trusted sites.', array('<code>/workspace/jit-image-manipulation/</code>')), Alert::ERROR);
+			} 
+
+			// Alert messages for JIT configuration errors
 			$errors = Symphony::Engine()->Page->_errors;
 			if (isset($errors['jit-trusted-sites'])) {
 				Symphony::Engine()->Page->pageAlert(
@@ -344,10 +350,10 @@
 			}
 
 			if (!$this->saveTrusted(stripslashes($_POST['jit_image_manipulation']['trusted_external_sites']))) {
-				$context['errors']['jit-trusted-sites'] = __('An error occurred while saving the JIT recipes. Make sure the recipes file, %s, is writable.', array('<code>/workspace/jit-image-manipulation/recipes.php</code>'));
+				$context['errors']['jit-trusted-sites'] = __('An error occurred while saving the JIT recipes. Make sure the recipes file, %s, exists and is writable.', array('<code>/workspace/jit-image-manipulation/recipes.php</code>'));
 			};
 			if (!$this->saveRecipes($_POST['jit_image_manipulation']['recipes'])) {
-				$context['errors']['jit-recipes'] = __('An error occurred while saving the JIT trusted sites. Make sure the trusted sites file, %s, is writable.', array('<code>/workspace/jit-image-manipulation/trusted-sites</code>'));
+				$context['errors']['jit-recipes'] = __('An error occurred while saving the JIT trusted sites. Make sure the trusted sites file, %s, exists and is writable.', array('<code>/workspace/jit-image-manipulation/trusted-sites</code>'));
 			};
 		}
 	}


### PR DESCRIPTION
This is th start of a fix for #27. Though in my installation I got a "Permission Denied" Symphony Warning instead of a normal page alert when the recipes or trusted sites couldn't be saved. But shouldn't `General::writeFile()` fail silently and just return false?

Sorry, didn't have the time to investigate further.
