### PR TITLE
Insert an ob_clean() prior to header output

### DIFF
--- a/lib/class.image.php
+++ b/lib/class.image.php
@@ -164,6 +164,7 @@
 		 *  than display it inline
 		 */
 		public static function renderOutputHeaders($type, $destination=NULL){
+			ob_clean();
 			header('Content-Type: ' . image_type_to_mime_type($type));
 
 			if(is_null($destination)) return;


### PR DESCRIPTION
It seems that in some rare instances not having this `ob_clean()` apache might output some potentially wrong headers and the image is output without any dimensions. And the browsers do not manage to detect the image as valid. Thus assume that the image is corrupted.

Note I was using 1.14 with Symphony 2.2.5 but I assume that this would still hold for future versions though very common only happened to me on one particular website. Info on issue can be found here[http://www.dave-schwab.com/2011/07/php-gd-error/] where the fix is explained 
