### PR TITLE
Option to prevent upscaling

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -385,6 +385,13 @@
 
 			$group->appendChild($label);
 
+			// checkbox to disable up-scaling
+			$label = Widget::Label();
+			$input = Widget::Input('settings[image][disable_upscaling]', 'yes', 'checkbox');
+			if (Symphony::Configuration()->get('disable_upscaling', 'image') == 'yes') $input->setAttribute('checked', 'checked');
+			$label->setValue($input->generate() . ' ' . __('Disable upscaling of images beyond the original size'));
+			$group->appendChild($label);
+
 			// textarea for trusted sites
 			$label = Widget::Label(__('Trusted Sites'));
 			$label->appendChild(Widget::Textarea('jit_image_manipulation[trusted_external_sites]', 5, 50, $this->trusted()));
@@ -398,6 +405,10 @@
 		public function __SavePreferences($context){
 			if(!isset($context['settings']['image']['disable_regular_rules'])){
 				$context['settings']['image']['disable_regular_rules'] = 'no';
+			}
+
+			if (!isset($context['settings']['image']['disable_upscaling'])) {
+				$context['settings']['image']['disable_upscaling'] = 'no';
 			}
 
 			// save trusted sites and recipes

--- a/lib/image.php
+++ b/lib/image.php
@@ -338,28 +338,31 @@
 		exit;
 	}
 
+	// Calculate the correct dimensions. If necessary, avoid upscaling the image.
+	$src_w = $image->Meta()->width;
+	$src_h = $image->Meta()->height;
+	if ($settings['image']['disable_upscaling'] == 'yes') {
+		$dst_w = min($param->width, $src_w);
+		$dst_h = min($param->height, $src_h);
+	} else {
+		$dst_w = $param->width;
+		$dst_h = $param->height;
+	}
+
 	// Apply the filter to the Image class (`$image`)
 	switch($param->mode) {
 		case MODE_RESIZE:
-			$image->applyFilter('resize', array($param->width, $param->height));
+			$image->applyFilter('resize', array($dst_w, $dst_h));
 			break;
 
 		case MODE_FIT:
-			$src_w = $image->Meta()->width;
-			$src_h = $image->Meta()->height;
-
-			$dst_w = $param->width;
-			$dst_h = $param->height;
-
 			if($param->height == 0) {
 				$ratio = ($src_h / $src_w);
-				$dst_w = $param->width;
 				$dst_h = round($dst_w * $ratio);
 			}
 
 			else if($param->width == 0) {
 				$ratio = ($src_w / $src_h);
-				$dst_h = $param->height;
 				$dst_w = round($dst_h * $ratio);
 			}
 
@@ -382,21 +385,13 @@
 			break;
 
 		case MODE_RESIZE_CROP:
-			$src_w = $image->Meta()->width;
-			$src_h = $image->Meta()->height;
-
-			$dst_w = $param->width;
-			$dst_h = $param->height;
-
 			if($param->height == 0) {
 				$ratio = ($src_h / $src_w);
-				$dst_w = $param->width;
 				$dst_h = round($dst_w * $ratio);
 			}
 
 			else if($param->width == 0) {
 				$ratio = ($src_w / $src_h);
-				$dst_h = $param->height;
 				$dst_w = round($dst_h * $ratio);
 			}
 
@@ -411,7 +406,7 @@
 			}
 
 		case MODE_CROP:
-			$image->applyFilter('crop', array($param->width, $param->height, $param->position, $param->background));
+			$image->applyFilter('crop', array($dst_w, $dst_h, $param->position, $param->background));
 			break;
 	}
 


### PR DESCRIPTION
I found this option useful for a project I'm working on, in which I don't want small images which are processed through jit transformations to be upscaled and anti-aliased.

A summary of changes:
- Add a checkbox option to the preferences page which disables upscaling
- Slight refactor of `lib/image.php` so that the sizes are calculated once
- Prevents upscaling for _all_ images and for _all_ image transformations when the option is set.

As long as the configuration option is not set, the behaviour of the extension should not have changed.
