### PR TITLE
Added sub domain wild card

### DIFF
--- a/lib/image.php
+++ b/lib/image.php
@@ -248,6 +248,11 @@
 				$allowed = true;
 				break;
 			}
+			
+			else if(substr($rule, 0, 1) == '*' && preg_match("/(".substr((substr($rule, -1) == '*' ? rtrim($rule, "/*") : $rule), 2).")/", $param->file)){
+				$allowed = true;
+				break;
+			}
 		}
 
 		if($allowed == false){


### PR DESCRIPTION
Before domains like i2.ytimg.com and farm6.staticflickr.com would fail.  This code allows you to add `*.vimeocdn.com/*``and``*.ytimg.com/*`` to your preferences so any subdomain will work
