### PR TITLE
Set GD to ignore invalid JPEGs

### DIFF
--- a/lib/image.php
+++ b/lib/image.php
@@ -1,6 +1,7 @@
 <?php
 
 	@ini_set('display_errors', 'off');
+	@ini_set("gd.jpeg_ignore_warning", 1);
 
 	define('DOCROOT', rtrim(realpath(dirname(__FILE__) . '/../../../'), '/'));
 	define('DOMAIN', rtrim(rtrim($_SERVER['HTTP_HOST'], '/') . str_replace('/extensions/jit_image_manipulation/lib', NULL, dirname($_SERVER['PHP_SELF'])), '/'));


### PR DESCRIPTION
In case the jpeg file is damaged, GD won't load it and throw errors. This commit fixes this by settings a GD flag as recommended by others.

It works :)
