### PR TITLE
check for $recipes existence prior to checking data type

### DIFF
--- a/lib/image.php
+++ b/lib/image.php
@@ -45,7 +45,8 @@
 		// Check for matching recipes
 		if(file_exists(WORKSPACE . '/jit-image-manipulation/recipes.php')) include(WORKSPACE . '/jit-image-manipulation/recipes.php');
 
-		if (is_array($recipes) && !empty($recipes)) {
+		// check to see if $recipes is even available before even checking if it is an array
+		if (!empty($recipes) && is_array($recipes)) {
 			foreach($recipes as $recipe) {
 				// Is the mode regex? If so, bail early and let not JIT process it.
 				if($recipe['mode'] === 'regex' && preg_match($recipe['url-parameter'], $string)) {


### PR DESCRIPTION
If there is no `recipes.php` file, then the `$recipes` array will not exist.  If the `is_array` method is called on an undefined variable, the process dies doesn't throw any useful server error.
