### PR TITLE
Fix getHttpResponseCode str/int equality mismatch

### DIFF
--- a/lib/image.php
+++ b/lib/image.php
@@ -287,7 +287,7 @@
 	if($param->mode == MODE_NONE){
 		if(
 			// If the external file still exists
-			($param->external && Image::getHttpResponseCode($original_file) !== "200")
+			($param->external && Image::getHttpResponseCode($original_file) != 200)
 			// If the file is local, does it exist and can we read it?
 			|| ($param->external === FALSE && (!file_exists($original_file) || !is_readable($original_file)))
 		) {


### PR DESCRIPTION
On line 290, the test for 200 HTTP response failed because the Gateway returns the HTTP code as a string, not an integer.  The previous library used in this extension (curl) returned an integer.  The equality test was strict, therefore "200" !== 200, even though the response code was OK.

This caused trouble with external images being pulled through the JIT since it would consider the remote file to be bad, even though it returned a 200 code, which then caused the local cache to also be unusable.

Honestly, I'd have preferred to have fixed the Gateway (to make it return an integer), but that seems to be too big of a hurdle since it's probably got some code relying on the fact it's a string these days.  C'est la vie.
