### PR TITLE
Remove ‘ob_clean’ function from renderOutputHeaders method

### DIFF
--- a/lib/class.image.php
+++ b/lib/class.image.php
@@ -171,7 +171,6 @@
 		 *  than display it inline
 		 */
 		public static function renderOutputHeaders($type, $destination=NULL){
-			ob_clean();
 			header('Content-Type: ' . image_type_to_mime_type($type));
 
 			if(is_null($destination)) return;


### PR DESCRIPTION
It was unnecessary and was causing errors in images in some environments. Sorts symphonycms/jit_image_manipulation#67
