### PR TITLE
turn zlib.output_compression off

### DIFF
--- a/lib/.htaccess
+++ b/lib/.htaccess
@@ -1,0 +1,1 @@
+php_flag zlib.output_compression off

--- a/lib/image.php
+++ b/lib/image.php
@@ -30,6 +30,7 @@
 	define_safe('CACHING', ($settings['image']['cache'] == 1 ? true : false));
 
 	set_error_handler('__errorHandler');
+	ob_start();
 
 	function processParams($string, &$image_settings){
 		$param = (object)array(


### PR DESCRIPTION
I had some problems with images generated with jit_image_manipulation on
server with zlib.output_compression set to 'on'.
Therefore I suggest disabling zlib.output_compression in .htaccess and
adding explicit call to ob_start to lib/image.php.
