### PR TITLE
Improve browser caching: add max-age directive

### DIFF
--- a/lib/image.php
+++ b/lib/image.php
@@ -246,7 +246,7 @@
 	if($last_modified) {
 		$last_modified_gmt = gmdate('D, d M Y H:i:s', $last_modified) . ' GMT';
 		$etag = md5($last_modified . $image_path);
-		$cacheControl = 'public';
+		$cacheControl = 'public; max-age=31536000';
 		
 		// Add no-transform in order to prevent ISPs to
 		// serve image over http through a compressing proxy


### PR DESCRIPTION
Right now, we're just sending a `public` Cache-Control directive. Google suggests:

> It is important to specify one of Expires or Cache-Control max-age, and one of Last-Modified or ETag, for all cacheable resources. It is redundant to specify both Expires and Cache-Control: max-age, or to specify both Last-Modified and ETag. 

 - https://developers.google.com/speed/docs/best-practices/caching?csw=1#LeverageBrowserCaching

This PR implements a Cache-Control max-age directive set to a year.