### PR TITLE
Reject invalid sizes

### DIFF
--- a/lib/image.php
+++ b/lib/image.php
@@ -341,7 +341,18 @@
 
 	// Make sure we have a valid size
 	if ($dst_w == 0 && $dst_h == 0) {
+		// Return 400
 		Page::renderStatusCode(Page::HTTP_STATUS_BAD_REQUEST);
+		// Init log
+		Symphony::initialiseLog();
+		// Get referrer
+		$httpRef = General::sanitize($_SERVER["HTTP_REFERER"]);
+		if (!$httpRef) {
+			$httpRef = 'unknown referrer';
+		}
+		// push to log
+		Symphony::Log()->pushToLog(sprintf('Invalid size (0 x 0) requested from "%s"', $httpRef), E_WARNING, true);
+		// output and exit
 		echo 'Both width and height can not be 0';
 		exit;
 	}

--- a/lib/image.php
+++ b/lib/image.php
@@ -339,6 +339,13 @@
 		$dst_h = $param->height;
 	}
 
+	// Make sure we have a valid size
+	if ($dst_w == 0 && $dst_h == 0) {
+		Page::renderStatusCode(Page::HTTP_STATUS_BAD_REQUEST);
+		echo 'Both width and height can not be 0';
+		exit;
+	}
+
 	// Apply the filter to the Image class (`$image`)
 	switch($param->mode) {
 		case MODE_RESIZE:


### PR DESCRIPTION
I came across lots of logs regarding jit image trying to use 0 x 0 has their dimensions. Each time it happend, 13 log entries where recreated!!! This fix now exit early in that case, to prevent poluting the log.

Should we still log it ? (but only once!)