### PR TITLE
Fix JIT error with regex recipes

### DIFF
--- a/lib/image.php
+++ b/lib/image.php
@@ -54,7 +54,7 @@
 					if (!empty($recipe['quality'])) {
 						$image_settings['quality'] = $recipe['quality'];
 					}
-					break 2;
+					break;
 				}
 				// Nope, we're not regex, so make a regex and then check whether we this recipe matches
 				// the URL string. If not, continue to the next recipe.


### PR DESCRIPTION
`break 2` is causing regex mode to fail. I am not sure why though as it makes sense to break out the `foreach` if the `$url-parameter` matches.

I’m using capture groups. Symphony errors out in both 2.3.6 (!) and 2.6.2. In both cases removing the break argument `2` resolves the issue. I don’t have the error log for 2.6.2 at hand, but 2.3.6 prints the following:

```txt
2015/08/12 23:48:43 > Warning: 2 - preg_match(): Unknown modifier 'r' in file /home/user/webapps/site/symphony/extensions/jit_image_manipulation/lib/image.php on line 63
2015/08/12 23:48:43 > Notice: Image class param dump - mode: 0, width: 0, height: 0, position: 0, background: 0, file: , external: 0, raw input: resize-width-huge-0/images/image.jpg
```

The JIT recipe file is this:

```php
<?php

	$recipes = array(

		########
		array(
			'mode' => 'regex',
			'name' => 'Resize Width Small',
			'url-parameter' => '/resize-width-small-([0-1])/i',
			'jit-parameter' => '1/800/0/$1',
			'quality' => '85',
		),
		########

		########
		array(
			'mode' => 'regex',
			'name' => 'Resize Width Medium',
			'url-parameter' => '/resize-width-medium-([0-1])/i',
			'jit-parameter' => '1/1200/0/$1',
			'quality' => '85',
		),
		########

		########
		array(
			'mode' => 'regex',
			'name' => 'Resize Width Large',
			'url-parameter' => '/resize-width-large-([0-1])/i',
			'jit-parameter' => '1/1800/0/$1',
			'quality' => '80',
		),
		########

		########
		array(
			'mode' => 'regex',
			'name' => 'Resize Width Huge',
			'url-parameter' => '/resize-width-huge-([0-1])/i',
			'jit-parameter' => '1/2400/0/$1',
			'quality' => '75',
		),
		########

	);

```