### PR TITLE
Support empty .htaccess files

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -49,7 +49,7 @@
 				$htaccess = str_replace($token, '$1', $htaccess);
 				$htaccess = preg_replace("/(" . PHP_EOL . "(\t)?){3,}/", PHP_EOL . PHP_EOL . "\t", $htaccess);
 
-				if(file_put_contents(DOCROOT . '/.htaccess', $htaccess)) {
+				if(file_put_contents(DOCROOT . '/.htaccess', $htaccess) !== false) {
 					// Now add Configuration values
 					Symphony::Configuration()->set('cache', '1', 'image');
 					Symphony::Configuration()->set('quality', '90', 'image');


### PR DESCRIPTION
The underlying issue here is dependency on distributed configuration 
files.

file_put_contents() returning zero is not a failure condition; it only
indicates that no bytes were written. Added a strict check to evaluate if
result was false.