### PR TITLE
Fix bug where regex mode was not detected properly

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -185,7 +185,7 @@
 						// collect recipe handle
 						$handles[] = $recipe['url-parameter'];
 					}
-					else if($mode === 'regex') {
+					else if($recipe['mode'] === 'regex') {
 						// regex already exists => set error
 						$this->recipes_errors[$position] = array(
 							'invalid' => __('A recipe with this regular expression already exists.')


### PR DESCRIPTION
The `$mode` variable was not defined anywhere; it's a key for `$regex` array.