### PR TITLE
Use comma in Cache-Control header for branche 1.x

### DIFF
--- a/lib/image.php
+++ b/lib/image.php
@@ -243,7 +243,7 @@ function __errorHandler($errno = null, $errstr, $errfile = null, $errline = null
         $etag = md5($last_modified . $image_path);
         // Use configured max-age or fallback on 3 days (See #88)
         $maxage = isset($settings['image']['max-age']) ? $settings['image']['max-age'] : 86400;
-        $cacheControl = 'public; max-age=' . $maxage;
+        $cacheControl = 'public, max-age=' . $maxage;
 
         // Add no-transform in order to prevent ISPs to
         // serve image over http through a compressing proxy


### PR DESCRIPTION
Same error as in the 2.x branche: See issue #146 https://github.com/symphonycms/jit_image_manipulation/issues/146