### PR TITLE
Fix behaviour for empty external responses

### DIFF
--- a/lib/class.image.php
+++ b/lib/class.image.php
@@ -57,7 +57,7 @@
 			// get the raw body response, ignore errors
 			$response = @$gateway->exec();
 
-			if($response === false){
+			if(!$response){
 				throw new Exception(sprintf('Error reading external image <code>%s</code>. Please check the URI.', $uri));
 			}
 
@@ -67,7 +67,7 @@
 			// Symphony 2.4 enhances the TMP constant so it can be relied upon
 			$dest = tempnam(TMP, 'IMAGE');
 
-			if(!file_put_contents($dest, $response)) {
+			if(file_put_contents($dest, $response) === false) {
 				throw new Exception(sprintf('Error writing to temporary file <code>%s</code>.', $dest));
 			}
 


### PR DESCRIPTION
The file_put_contents function will return 0 if empty content is written, but this should not trigger a writing exception. Empty content should throw an exception before, when checking the curl response.

Fixes #164