### PR TITLE
Prevent warning for index larger than pallet size

### DIFF
--- a/lib/class.imagefilter.php
+++ b/lib/class.imagefilter.php
@@ -18,7 +18,8 @@
 
 			if(!$colour || strlen(trim($colour)) == 0){
 				$tr_idx = imagecolortransparent($res);
-				if($tr_idx >= 0){
+				$palletsize = imagecolorstotal($res);
+				if($tr_idx >= 0 && $tr_idx < $palletsize){
 					$tr_colour = imagecolorsforindex($res, $tr_idx);
 					$tr_idx = imagecolorallocate($dst, $tr_colour['red'], $tr_colour['green'], $tr_colour['blue']);
 					imagefill($dst, 0, 0, $tr_idx);


### PR DESCRIPTION
PHP throws a "Warning: imagecolorsforindex(): Color index ... out of range in..." if the index returned by imagecolortransparent() is larger than the pallet size of the image in question.

See https://stackoverflow.com/a/3898007

Fixes #165