### PR TITLE
Throw E_USER_NOTICE instead of E_USER_ERROR

### DIFF
--- a/lib/image.php
+++ b/lib/image.php
@@ -348,7 +348,7 @@
 	}
 	catch(Exception $e){
 		Page::renderStatusCode(Page::HTTP_STATUS_BAD_REQUEST);
-		trigger_error($e->getMessage(), E_USER_ERROR);
+		trigger_error($e->getMessage(), E_USER_NOTICE);
 		echo $e->getMessage();
 		exit;
 	}


### PR DESCRIPTION
When an image can not be loaded, a E_USER_ERROR is thrown. But Symphony's 404 errors, for example, trigger E_USER_NOTICE exceptions. So the latter should be enough here as well.

This will allow to run big systems with suppressed notices, thus preventing the log file from being polluted with image errors (mainly caused by robots anyway).

Fixes #166